### PR TITLE
undisturbStatue refresh after lanuch app

### DIFF
--- a/EaseIMKit/EaseIMKit/Classes/Conversations/Controllers/EaseConversationsViewController.m
+++ b/EaseIMKit/EaseIMKit/Classes/Conversations/Controllers/EaseConversationsViewController.m
@@ -56,6 +56,16 @@ EMClientDelegate
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(refreshTabView)
                                                  name:CONVERSATIONLIST_UPDATE object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(refreshConversations)
+                                                 name:@"EMUserPushConfigsUpdateSuccess" object:nil];
+    
+}
+
+- (void)refreshConversations {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self.tableView reloadData];
+    });
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -94,7 +104,9 @@ EMClientDelegate
     [[EMClient sharedClient].pushManager getPushNotificationOptionsFromServerWithCompletion:^(EMPushOptions * _Nonnull aOptions, EMError * _Nonnull aError) {
         if (!aError) {
             [[EaseIMKitManager shared] cleanMemoryUndisturbMaps];
-            [self.tableView reloadData];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [self.tableView reloadData];
+            });
         }
     }];
 }


### PR DESCRIPTION
App杀死重新启动后获取pushconfig的时候，UI提前刷新导致会话列表的免打扰状态不正确，需要在appdelegate中获取pushconfig成功后发送通知，在conversations列表中刷新list